### PR TITLE
Adding the ability to add custom metadata to the error event

### DIFF
--- a/src/Event/CommandErrorEvent.php
+++ b/src/Event/CommandErrorEvent.php
@@ -5,6 +5,8 @@ namespace GuzzleHttp\Command\Event;
 use GuzzleHttp\Event\ErrorEvent;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\ServiceClientInterface;
+use GuzzleHttp\HasDataTrait;
+use GuzzleHttp\ToArrayInterface;
 
 /**
  * Event emitted when an error occurs while transferring a request for a
@@ -13,8 +15,14 @@ use GuzzleHttp\Command\ServiceClientInterface;
  * Event listeners can inject a result onto the event to intercept the
  * exception with a successful result.
  */
-class CommandErrorEvent extends AbstractCommandEvent
+class CommandErrorEvent extends AbstractCommandEvent implements
+    ToArrayInterface,
+    \Countable,
+    \ArrayAccess,
+    \IteratorAggregate
 {
+    use HasDataTrait;
+
     /** @var ErrorEvent */
     private $errorEvent;
 

--- a/tests/Event/CommandErrorEventTest.php
+++ b/tests/Event/CommandErrorEventTest.php
@@ -36,5 +36,9 @@ class ErrorEventTest extends \PHPUnit_Framework_TestCase
         $event->setResult('foo');
         $this->assertSame('foo', $event->getResult());
         $this->assertTrue($event->isPropagationStopped());
+
+        $this->assertNull($event['abc']);
+        $event['abc'] = 'foo';
+        $this->assertEquals('foo', $event['abc']);
     }
 }


### PR DESCRIPTION
This could be useful in something like the AWS SDK where you could add a listener that parses exceptions and adds custom metadata from the parsed exception. This extra data could also be used if the error event is not handled (and not sending the command in parallel) to create a custom subclass of CommandException. @jeremeamia
