### PR TITLE
Added an emitter option to the AbstractClient class

### DIFF
--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -45,6 +45,9 @@ abstract class AbstractClient implements ServiceClientInterface
         if (!isset($config['defaults'])) {
             $config['defaults'] = [];
         }
+        if (isset($config['emitter'])) {
+            $this->emitter = $config['emitter'];
+        }
         $this->config = new Collection($config);
     }
 

--- a/tests/AbstractClientTest.php
+++ b/tests/AbstractClientTest.php
@@ -220,6 +220,23 @@ class AbstractClientTest extends \PHPUnit_Framework_TestCase
         $mock->executeAll([$command], ['parallel' => 10]);
     }
 
+    public function testCanInjectEmitter()
+    {
+        $guzzleClient = $this->getMock('GuzzleHttp\\ClientInterface');
+        $emitter = $this->getMockBuilder('GuzzleHttp\Event\EmitterInterface')
+            ->setMethods(['listeners'])
+            ->getMockForAbstractClass();
+        $serviceClient = $this->getMockBuilder('GuzzleHttp\\Command\\AbstractClient')
+            ->setConstructorArgs([$guzzleClient, ['emitter' => $emitter]])
+            ->getMockForAbstractClass();
+
+        $emitter->expects($this->once())
+            ->method('listeners')
+            ->will($this->returnValue('foo'));
+
+        $this->assertEquals('foo', $serviceClient->getEmitter()->listeners());
+    }
+
     private function getWrapCount(\Exception $e)
     {
         $c = 0;


### PR DESCRIPTION
This change allows to inject the event emitter into service clients which would be handy when configuring clients with a DI container. The same option has been added to the regular Guzzle client [before](https://github.com/guzzle/guzzle/pull/642). 
