### PR TITLE
Added a subscriber to easily mock the results of a command.

### DIFF
--- a/src/Subscriber/ResultMock.php
+++ b/src/Subscriber/ResultMock.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace GuzzleHttp\Command\Subscriber;
+
+use GuzzleHttp\Command\Event\PrepareEvent;
+use GuzzleHttp\Command\Exception\CommandException;
+use GuzzleHttp\Event\SubscriberInterface;
+
+/**
+ * Queues mock results and/or exceptions and delivers them in a FIFO order.
+ */
+class ResultMock implements SubscriberInterface, \Countable
+{
+    /** @var array Array of mock results and exceptions */
+    private $queue = [];
+
+    /**
+     * @param array $results Array of results and exceptions to queue
+     */
+    public function __construct(array $results = [])
+    {
+        $this->addMultiple($results);
+    }
+
+    public function getEvents()
+    {
+        // Fire the event during command preparation, so request or response
+        // ever needs to be created.
+        return ['prepare' => ['onPrepare', 'first']];
+    }
+
+    /**
+     * @throws CommandException if one has been queued.
+     * @throws \OutOfBoundsException if the queue is empty.
+     */
+    public function onPrepare(PrepareEvent $event)
+    {
+        if (!$result = array_shift($this->queue)) {
+            throw new \OutOfBoundsException('Result mock queue is empty');
+        } elseif ($result instanceof CommandException) {
+            throw $result;
+        } elseif ($result instanceof \Exception) {
+            // Use the message and event data to create a CommandException
+            throw new CommandException(
+                $result->getMessage(),
+                $event->getClient(),
+                $event->getCommand()
+            );
+        } else {
+            $event->setResult($result);
+        }
+    }
+
+    public function count()
+    {
+        return count($this->queue);
+    }
+
+    /**
+     * Add a result to the end of the queue.
+     *
+     * @param mixed $result The result of the command.
+     *
+     * @return self
+     */
+    public function addResult($result)
+    {
+        $this->queue[] = $result;
+
+        return $this;
+    }
+
+    /**
+     * Add an exception to the end of the queue.
+     *
+     * @param CommandException $exception Thrown when the command is executed.
+     *
+     * @return self
+     */
+    public function addException(CommandException $exception)
+    {
+        $this->queue[] = $exception;
+
+        return $this;
+    }
+
+    /**
+     * Add an exception to the end of the queue, by specifying the message only.
+     *
+     * @param string $message Message used in the exception thrown when the command is executed.
+     *
+     * @throws \InvalidArgumentException if something other than a string is provided.
+     * @return self
+     */
+    public function addExceptionMessage($message)
+    {
+        if (!is_string($message)) {
+            throw new \InvalidArgumentException('You must provide a string.');
+        }
+
+        // A vanilla exception is used to transport the message, so that when it
+        // is taken off the queue, we will know that it was not meant to be a
+        // result, since results can be anything. The value will be used to
+        // create a CommandException, which is what will actually be thrown.
+        $this->queue[] = new \Exception($message);
+
+        return $this;
+    }
+
+    /**
+     * Add multiple results/exceptions to the queue
+     *
+     * @param array $results Results to add
+     *
+     * @return self
+     */
+    public function addMultiple(array $results)
+    {
+        foreach ($results as $result) {
+            if ($result instanceof \Exception) {
+                $this->addException($result);
+            } else {
+                $this->addResult($result);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clear the queue.
+     *
+     * @return self
+     */
+    public function clearQueue()
+    {
+        $this->queue = [];
+
+        return $this;
+    }
+}

--- a/tests/Subscriber/ResultMockTest.php
+++ b/tests/Subscriber/ResultMockTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace GuzzleHttp\Tests\Subscriber;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Command\Command;
+use GuzzleHttp\Command\Event\PrepareEvent;
+use GuzzleHttp\Command\Exception\CommandException;
+use GuzzleHttp\Command\Model;
+use GuzzleHttp\Command\Subscriber\ResultMock;
+
+/**
+ * @covers GuzzleHttp\Command\Subscriber\ResultMock
+ */
+class ResultMockTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDescribesSubscribedEvents()
+    {
+        $mock = new ResultMock();
+        $this->assertInternalType('array', $mock->getEvents());
+    }
+
+    public function testIsCountable()
+    {
+        $client = $this->getMock('GuzzleHttp\\Command\\ServiceClientInterface');
+        $plugin = (new ResultMock)->addMultiple([
+            new Model([]),
+            new CommandException('foo', $client, new Command('foo')),
+        ]);
+        $this->assertEquals(2, count($plugin));
+    }
+
+    public function testCanClearQueue()
+    {
+        $plugin = new ResultMock();
+        $plugin->addResult(['foo' => 'bar']);
+        $plugin->clearQueue();
+        $this->assertEquals(0, count($plugin));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionWhenInvalidExceptionMessage()
+    {
+        (new ResultMock())->addExceptionMessage(5);
+    }
+
+    public function testCanMockCommandResults()
+    {
+        $client = $this->getMockBuilder('GuzzleHttp\\Command\\AbstractClient')
+            ->setConstructorArgs([new Client])
+            ->getMockForAbstractClass();
+
+        $plugin = (new ResultMock)
+            ->addResult(new Model(['foo' => 'bar']))
+            ->addException(new CommandException('A', $client, new Command('foo')))
+            ->addExceptionMessage('B');
+
+        // 1. The Model object
+        $event = new PrepareEvent(new Command('foo'), $client);
+        $plugin->onPrepare($event);
+        $this->assertInstanceOf('GuzzleHttp\Command\Model', $event->getResult());
+
+        // 2. The Exception with "A"
+        try {
+            $plugin->onPrepare(new PrepareEvent(new Command('foo'), $client));
+        } catch (CommandException $e) {
+            $this->assertEquals('A', $e->getMessage());
+        }
+
+        // 2. The Exception with "B"
+        try {
+            $plugin->onPrepare(new PrepareEvent(new Command('foo'), $client));
+        } catch (CommandException $e) {
+            $this->assertEquals('B', $e->getMessage());
+        }
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     */
+    public function testUpdateThrowsExceptionWhenEmpty()
+    {
+        $client = $this->getMockBuilder('GuzzleHttp\\Command\\AbstractClient')
+            ->setConstructorArgs([new Client])
+            ->getMockForAbstractClass();
+        $event = new PrepareEvent(new Command('foo'), $client);
+        (new ResultMock)->onPrepare($event);
+    }
+}


### PR DESCRIPTION
This PR adds a subscriber to the Command package that correlates to the Mock subscriber in the Guzzle core. It allows you to mock results and exceptions at the command level. This is a rough POC that i wanted you to review. Let me know if you like it or not and if you want to change any class/method names.

Here is a example of how it is used.

``` php
<?php

require __DIR__ . '/../vendor/autoload.php';

use GuzzleHttp\Client;
use GuzzleHttp\Command\AbstractClient;
use GuzzleHttp\Command\Command;
use GuzzleHttp\Command\Subscriber\ResultMock;
use GuzzleHttp\Command\Model;

// Create a client
class ServiceClient extends AbstractClient {
    public function getCommand($name, array $args = []) {
        return new Command($name, $args, clone $this->getEmitter());
    }
}
$client = new ServiceClient(new Client);

// Setup mock plugin
$mock = new ResultMock();
$mock->addResult(new Model(['foo' => 'bar']));
$mock->addExceptionMessage('Whoops!');
$client->getEmitter()->attach($mock);

// Should return a model with ['foo' => 'bar']
print_r($client->getThing()->toArray());

// Should throw a CommandException with message "Whoops!"
try {
    $client->getThing();
} catch (\Exception $e) {
    echo "EXCEPTION: " . $e->getMessage() . "\n";
}
```
