### PR TITLE
Updated the suggested version constraint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ composer.json:
 
     {
         "require": {
-            "guzzlehttp/command": "~0.7"
+            "guzzlehttp/command": "0.7.*"
         }
     }
 


### PR DESCRIPTION
It might be an idea to use a stricter version constraint until we reach 1.0.
