### PR TITLE
Return empty array instead of null when $this->config[$keyOrPath] is unset

### DIFF
--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -134,7 +134,7 @@ abstract class AbstractClient implements ServiceClientInterface
         if (strpos($keyOrPath, '/') === false) {
             return isset($this->config[$keyOrPath])
                 ? $this->config[$keyOrPath]
-                : null;
+                : [];
         }
 
         return Utils::getPath($this->config, $keyOrPath);


### PR DESCRIPTION
This would manifest as an "unsupported operand types" fatal error in guzzle-services/src/GuzzleClient.php, which assumes that the return from getConfig() is always an array.

Either this or guzzle/guzzle-services#84 will resolve the issue, I'm leaving it up to the upstream authors to decide which approach is more appropriate since the return type of `getConfig()` is a design decision.