### PR TITLE
Update to Guzzle 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build/
 phpunit.xml
 composer.lock
 vendor/
+
+# testing
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 php:
+  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
 
 before_script:
   - curl --version
+  - composer self-update
   - composer install --no-interaction --prefer-source --dev
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 before_script:
   - curl --version
@@ -17,6 +16,4 @@ before_script:
 script: make test
 
 matrix:
-  allow_failures:
-    - php: hhvm
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ sudo: false
 dist: trusty
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
+  - 7.2.5
+  - 7.3
+  - 7.4
 
 before_script:
   - curl --version

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/guzzle": "^6.2|^7.0.1",
         "guzzlehttp/promises": "~1.3",
         "guzzlehttp/psr7": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.2|^7.0.1",
+        "php": ">=7.2.5",
+        "guzzlehttp/guzzle": "^7.0.1",
         "guzzlehttp/promises": "~1.3",
         "guzzlehttp/psr7": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "guzzlehttp/psr7": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0|~5.0"
+        "phpunit/phpunit": "^8.5.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace GuzzleHttp\Tests\Command;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\HandlerStack;
 
 /**
  * @covers \GuzzleHttp\Command\Command
  */
-class CommandTest extends \PHPUnit_Framework_TestCase
+class CommandTest extends TestCase
 {
     public function testHasData()
     {

--- a/tests/Exception/CommandExceptionTest.php
+++ b/tests/Exception/CommandExceptionTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\CommandException;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Exception\CommandClientException;
 use GuzzleHttp\Command\Exception\CommandException;
@@ -12,7 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * @covers \GuzzleHttp\Command\Exception\CommandException
  */
-class CommandExceptionTest extends \PHPUnit_Framework_TestCase
+class CommandExceptionTest extends TestCase
 {
     public function testCanGetDataFromException()
     {

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace GuzzleHttp\Tests\Command;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Command\Result;
 
 /**
  * @covers \GuzzleHttp\Command\Result
  * @covers \GuzzleHttp\Command\HasDataTrait
  */
-class ResultTest extends \PHPUnit_Framework_TestCase
+class ResultTest extends TestCase
 {
     public function testHasData()
     {
@@ -20,6 +21,6 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         unset($c['fizz']);
         $this->assertCount(1, $c);
         $this->assertInstanceOf('Traversable', $c->getIterator());
-        $this->assertContains('bar', (string) $c);
+        $this->assertStringContainsString('bar', (string) $c);
     }
 }

--- a/tests/ServiceClientTest.php
+++ b/tests/ServiceClientTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Command\Guzzle;
 
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\CommandInterface;
@@ -18,7 +19,7 @@ use GuzzleHttp\Psr7\Request;
 /**
  * @covers \GuzzleHttp\Command\ServiceClient
  */
-class ServiceClientTest extends \PHPUnit_Framework_TestCase
+class ServiceClientTest extends TestCase
 {
     private function getServiceClient(array $responses)
     {
@@ -78,7 +79,7 @@ class ServiceClientTest extends \PHPUnit_Framework_TestCase
             ),
         ]);
 
-        $this->setExpectedException(CommandException::class);
+        $this->expectException(CommandException::class);
         $client->execute($client->getCommand('foo'));
     }
 
@@ -127,7 +128,7 @@ class ServiceClientTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Result::class, $results[0]);
         $this->assertEquals('A', $results[0]['letter']);
         $this->assertInstanceOf(CommandException::class, $results[1]);
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Not a letter',
             (string) $results[1]->getResponse()->getBody()
         );
@@ -141,7 +142,7 @@ class ServiceClientTest extends \PHPUnit_Framework_TestCase
             yield 'foo';
         };
 
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $client = $this->getServiceClient([]);
         $client->executeAll($generateCommands());


### PR DESCRIPTION
Added support for Guzzle 7 (7.0.1).
Guzzle 7 is the minimum version for Laravel 8.

Tests run fine.