### PR TITLE
Remove PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm


### PR DESCRIPTION
Remove PHP 5.5 from travis as xenial is now default dist.