### PR TITLE
Fix Guzzle error processing with http_errors=true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .phpunit.result.cache
 composer.lock
 vendor/
-
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .phpunit.result.cache
 composer.lock
 vendor/
+
+.idea/


### PR DESCRIPTION
When Guzzle option http_errors=true this errorResponses not processing and this code skipped during exception:
`yield $this->transformResponseToResult($response, $request, $command);`
This fix allow errorResponses mappings from Description. 
If error not found in errorResponses than Guzzle error will propagate.