### PR TITLE
Update CI workflows and add PHPStan

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,11 +11,11 @@ permissions:
 jobs:
   composer-normalize:
     name: Composer Normalize
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Composer normalize
         uses: docker://ergebnis/composer-normalize-action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build-lowest-version:
     name: Build lowest version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Set up PHP
@@ -23,7 +23,7 @@ jobs:
           extensions: mbstring
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: composer update --no-interaction --prefer-stable --prefer-lowest --no-progress
@@ -33,11 +33,11 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Set up PHP
@@ -49,7 +49,7 @@ jobs:
           extensions: mbstring
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: composer update --no-interaction --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       max-parallel: 10
       matrix:
         php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,13 +9,37 @@ permissions:
   contents: read
 
 jobs:
-  php-cs-fixer:
-    name: PHP-CS-Fixer
-    runs-on: ubuntu-22.04
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+          extensions: mbstring
+
+      - name: Download dependencies
+        run: composer update --no-interaction --no-progress
+
+      - name: Download PHPStan
+        run: composer bin phpstan update --no-interaction --no-progress
+
+      - name: Execute PHPStan
+        run: vendor/bin/phpstan analyze --no-progress
+
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -23,7 +47,6 @@ jobs:
           php-version: '7.4'
           coverage: none
           extensions: mbstring
-          tools: composer
 
       - name: Download dependencies
         run: composer update --no-interaction --no-progress

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,25 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: src/Command.php
+
+		-
+			message: '#^Callable callable\(Psr\\Http\\Message\\RequestInterface, array\)\: GuzzleHttp\\Promise\\PromiseInterface invoked with 1 parameter, 2 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/ServiceClient.php
+
+		-
+			message: '#^Parameter \#1 of callable callable\(Psr\\Http\\Message\\RequestInterface, array\)\: GuzzleHttp\\Promise\\PromiseInterface expects Psr\\Http\\Message\\RequestInterface, GuzzleHttp\\Command\\CommandInterface given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ServiceClient.php
+
+		-
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
+			count: 1
+			path: src/ServiceClient.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - src

--- a/src/ServiceClient.php
+++ b/src/ServiceClient.php
@@ -153,9 +153,9 @@ class ServiceClient implements ServiceClientInterface
             $command = $this->getCommand(substr($name, 0, -5), $args);
 
             return $this->executeAsync($command);
-        } else {
-            return $this->execute($this->getCommand($name, $args));
         }
+
+        return $this->execute($this->getCommand($name, $args));
     }
 
     /**

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
-        "php": "^7.4 || ^8.0",
-        "friendsofphp/php-cs-fixer": "3.68.5"
+        "php": "^7.4",
+        "friendsofphp/php-cs-fixer": "3.94.2"
     },
     "config": {
         "preferred-install": "dist"

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "php": "^8.2",
+        "phpstan/phpstan": "2.1.40",
+        "phpstan/phpstan-deprecation-rules": "2.0.3"
+    },
+    "config": {
+        "preferred-install": "dist"
+    }
+}


### PR DESCRIPTION
## Summary
- Standardize all workflow files: ubuntu-24.04, actions/checkout@v6, PHP 8.5 in matrix
- Add PHPStan (level 5) with baseline
- Upgrade php-cs-fixer to 3.94.2 and apply fixes
- Upgrade bamarni/composer-bin-plugin to 1.9.1

## Test plan
- [ ] CI passes: checks, static analysis, and tests