### PR TITLE
Prepare 2.0 dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '7.4'
           ini-values: error_reporting=E_ALL
           coverage: 'none'
           extensions: mbstring
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.0.0 - UPCOMING
+
+* Drop support for PHP 7.2 and 7.3
+* Require `guzzlehttp/guzzle` ^8.0, `guzzlehttp/promises` ^3.0, and `guzzlehttp/psr7` ^3.0
+
 ## 1.4.0 - 2026-05-18
 
 * Add PHP 8.5 support

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ This project can be installed using [Composer](https://getcomposer.org/):
 composer require guzzlehttp/command
 ```
 
+## Version Guidance
+
+| Version | Status              | PHP Version  |
+|---------|---------------------|--------------|
+| 1.x     | Latest              | >=7.2.5,<8.6 |
+| 2.x     | Experimental        | >=7.4,<8.6   |
+
+See [UPGRADING.md](UPGRADING.md) for notes on upgrading to 2.0.
+
 ## Service Clients
 
 Service Clients are web service clients that implement the

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,33 @@
+Guzzle Command Upgrade Guide
+============================
+
+1.x to 2.0
+----------
+
+#### PHP Version and Dependencies
+
+Guzzle Command 2.0 requires PHP `^7.4 || ^8.0`. Guzzle Command 1.x supported
+PHP `^7.2.5 || ^8.0`.
+
+Guzzle Command 2.0 also requires Guzzle 8.x, Guzzle Promises 3.x, and Guzzle
+PSR-7 3.x.
+
+If your application still supports PHP 7.2 or 7.3, or still uses the Guzzle 7
+dependency stack, continue using Guzzle Command 1.x until your minimum PHP and
+dependency versions are raised.
+
+#### Per-command HTTP Options
+
+`GuzzleHttp\Command\ServiceClient` still reserves the `@http` command parameter
+for per-command Guzzle request options. These options are passed to the
+underlying Guzzle client when the command is executed.
+
+Review the Guzzle 8 upgrade guide for request option changes, especially
+stricter `proxy` option validation and the extra request argument passed to
+`on_headers` callbacks.
+
+#### Asynchronous Commands
+
+`executeAsync()` and `executeAllAsync()` now return promises from Guzzle Promises
+3.x. Code using Guzzle Promises directly should review the Guzzle Promises 3.0
+upgrade guide.

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
-        "guzzlehttp/guzzle": "^7.10",
-        "guzzlehttp/promises": "^2.3",
-        "guzzlehttp/psr7": "^2.8"
+        "php": "^7.4 || ^8.0",
+        "guzzlehttp/guzzle": "^8.0@dev",
+        "guzzlehttp/promises": "^3.0@dev",
+        "guzzlehttp/psr7": "^3.0@dev"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",


### PR DESCRIPTION
This prepares the 2.0 branch for the next Guzzle stack by dropping PHP 7.2 and 7.3 and requiring Guzzle 8, Promises 3, and PSR-7 3. It also adds version guidance and an upgrade guide.