### PR TITLE
Improve command typing PHPDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Require service client response transformers to return `ResultInterface` values
 * Require custom middleware, transformers, and `executeAll()` callbacks to accept exact argument types instead of relying on scalar coercion
 * Preserve requests from PSR-18 request and network exceptions when wrapping command failures
+* Improve PHPDoc for command handler stacks, transformer callables, and concurrent command callbacks
 
 ## 1.4.0 - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -52,13 +52,10 @@ can be instantiated by providing the following arguments:
 1. A fully-configured Guzzle HTTP client that will be used to perform the
    underlying HTTP requests. That is, an instance of an object implementing
    `GuzzleHttp\ClientInterface` such as `new GuzzleHttp\Client()`.
-1. A callable that transforms a Command into a Request. The function should
-   accept a `GuzzleHttp\Command\CommandInterface` object and return a
-   `Psr\Http\Message\RequestInterface` object.
-1. A callable that transforms a Response into a Result. The function should
-   accept a `Psr\Http\Message\ResponseInterface` object and optionally a
-   `Psr\Http\Message\RequestInterface` object, and return a
-   `GuzzleHttp\Command\ResultInterface` object.
+1. A callable that transforms a Command into a Request. The callable is invoked
+   as `callable(GuzzleHttp\Command\CommandInterface): Psr\Http\Message\RequestInterface`.
+1. A callable that transforms a Response into a Result. The callable is invoked
+   as `callable(Psr\Http\Message\ResponseInterface, Psr\Http\Message\RequestInterface, GuzzleHttp\Command\CommandInterface): GuzzleHttp\Command\ResultInterface`.
 1. Optionally, a Guzzle HandlerStack (`GuzzleHttp\HandlerStack`), which can be
    used to add command-level middleware to the service client.
 
@@ -181,8 +178,7 @@ execute the same operation again with the same per-command HTTP options.
 ## Asynchronous Commands
 
 Commands can be executed asynchronously using `executeAsync()`. This method
-returns a `GuzzleHttp\Promise\PromiseInterface` that resolves to a
-`GuzzleHttp\Command\ResultInterface`.
+returns a `GuzzleHttp\Promise\PromiseInterface<GuzzleHttp\Command\ResultInterface, mixed>`.
 
 ```php
 use GuzzleHttp\Command\ResultInterface;
@@ -213,11 +209,11 @@ $promise = $client->fooAsync(['baz' => 'bar']);
 $result = $promise->wait();
 ```
 
-If execution fails, the promise is rejected with a
+If built-in execution fails, the promise is typically rejected with a
 `GuzzleHttp\Command\Exception\CommandException`. When HTTP errors are enabled,
 4xx and 5xx responses are represented by `CommandClientException` and
 `CommandServerException`, respectively, when the underlying Guzzle exception
-contains a response.
+contains a response. Custom middleware and handlers may reject with other values.
 
 ## Concurrent Requests
 
@@ -227,7 +223,10 @@ fixed concurrency limit. Both methods accept an array or iterator that yields
 
 `executeAll()` waits for the pool to finish and returns an array keyed like the
 input commands. Successful entries contain results. Failed entries contain the
-rejection reason, typically a `CommandException`.
+rejection reason, typically a `CommandException`. Callback keys may be integers,
+strings, or `null`. Returned array keys follow PHP array-key normalization;
+numeric-string keys may become integers, and `null` keys are stored as an empty
+string.
 
 ```php
 use GuzzleHttp\Command\ResultInterface;
@@ -249,11 +248,21 @@ $results = $client->executeAll($commands, [
 ```
 
 `executeAllAsync()` returns a promise for the command pool instead of waiting for
-it immediately. The same options are supported:
+it immediately. Fulfilled and rejected callbacks may also declare the aggregate
+promise as a third argument:
 
 ```php
+use GuzzleHttp\Command\ResultInterface;
+use GuzzleHttp\Promise\PromiseInterface;
+
 $promise = $client->executeAllAsync($commands, [
     'concurrency' => 10,
+    'fulfilled' => function (ResultInterface $result, $key, PromiseInterface $aggregate) {
+        // Called when one command succeeds.
+    },
+    'rejected' => function ($reason, $key, PromiseInterface $aggregate) {
+        // Called when one command fails.
+    },
 ]);
 
 $promise->wait();
@@ -263,10 +272,12 @@ The supported options are:
 
 * `concurrency`: Maximum number of commands to execute at the same time. The
   default is `25`.
-* `fulfilled`: Callable invoked as `fulfilled($result, $key)` when an individual
-  command succeeds.
-* `rejected`: Callable invoked as `rejected($reason, $key)` when an individual
-  command fails.
+* `fulfilled`: Callable invoked as `fulfilled($result, $key)` by `executeAll()`
+  when an individual command succeeds. `executeAllAsync()` also passes the
+  aggregate promise as a third argument.
+* `rejected`: Callable invoked as `rejected($reason, $key)` by `executeAll()`
+  when an individual command fails. `executeAllAsync()` also passes the aggregate
+  promise as a third argument.
 
 Choose a concurrency value that is appropriate for the remote service and your
 application. Very large command lists should generally be streamed with an
@@ -279,8 +290,8 @@ implement additional behavior and customize the ``Command``-to-``Result`` and
 ``Request``-to-``Response`` lifecycles, respectively.
 
 Command middleware is added to the service client's handler stack and wraps
-commands before they are transformed into HTTP requests. HTTP middleware should
-be configured on the underlying Guzzle HTTP client instead.
+commands before they are transformed into HTTP requests. Command handlers use the
+shape `callable(GuzzleHttp\Command\CommandInterface): GuzzleHttp\Promise\PromiseInterface<GuzzleHttp\Command\ResultInterface, mixed>`. HTTP middleware should be configured on the underlying Guzzle HTTP client instead.
 
 ```php
 use GuzzleHttp\Command\CommandInterface;

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -65,18 +65,26 @@ callbacks.
 3.x. Code using Guzzle Promises directly should account for its 3.0 behavior and
 signature changes.
 
-#### Static Analysis PHPDoc
+#### Generic Promise And Structured PHPDoc Types
 
-Guzzle Command 2.0 documents command handler stacks, transformer callables, and
-concurrent command callbacks more precisely for static analysis. Command handler
-stacks are documented as handlers that accept `CommandInterface` and return
-`PromiseInterface<ResultInterface, mixed>`. Command-to-request transformers are
-documented as receiving `CommandInterface`, and response-to-result transformers
-are documented as receiving `ResponseInterface`, `RequestInterface`, and
-`CommandInterface`.
+Guzzle Command's async service client APIs and command handler stack annotations
+now use generic `PromiseInterface<ResultInterface, mixed>` PHPDoc types. This is
+a static-analysis-only change and does not alter runtime behavior, but projects
+with stricter static analysis may see new or different diagnostics.
 
-`executeAll()` callbacks are documented with the result or rejection reason and
-the command key. `executeAllAsync()` callbacks are documented with the same first
+Code using unparameterized promise types continues to work. If your project
+implements `ServiceClientInterface`, provides custom command middleware, or
+documents reusable command handlers, you may need to update your PHPDoc
+annotations to include promise fulfillment and rejection types.
+
+Transformer, `executeAll()`, and `executeAllAsync()` option PHPDoc now uses
+structured array and callable shapes. This does not change runtime behavior, but
+stricter static analysis may now report invalid option keys, invalid option value
+types, or callback annotations that were previously hidden behind loose `array`
+or `callable` PHPDoc.
+
+`executeAll()` callback annotations include the result or rejection reason and
+the command key. `executeAllAsync()` callback annotations include the same first
 two arguments plus the aggregate promise as a third argument. Lower-arity
 userland callbacks continue to work at runtime when PHP accepts them.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -65,6 +65,21 @@ callbacks.
 3.x. Code using Guzzle Promises directly should account for its 3.0 behavior and
 signature changes.
 
+#### Static Analysis PHPDoc
+
+Guzzle Command 2.0 documents command handler stacks, transformer callables, and
+concurrent command callbacks more precisely for static analysis. Command handler
+stacks are documented as handlers that accept `CommandInterface` and return
+`PromiseInterface<ResultInterface, mixed>`. Command-to-request transformers are
+documented as receiving `CommandInterface`, and response-to-result transformers
+are documented as receiving `ResponseInterface`, `RequestInterface`, and
+`CommandInterface`.
+
+`executeAll()` callbacks are documented with the result or rejection reason and
+the command key. `executeAllAsync()` callbacks are documented with the same first
+two arguments plus the aggregate promise as a third argument. Lower-arity
+userland callbacks continue to work at runtime when PHP accepts them.
+
 1.0 from 0.8
 ------------
 

--- a/src/Command.php
+++ b/src/Command.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Command;
 
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\PromiseInterface;
 
 /**
  * Default command implementation.
@@ -15,12 +16,13 @@ class Command implements CommandInterface
 
     private string $name;
 
+    /** @var HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>>|null */
     private ?HandlerStack $handlerStack;
 
     /**
-     * @param string            $name         Name of the command
-     * @param array             $args         Arguments to pass to the command
-     * @param HandlerStack|null $handlerStack Stack of middleware for the command
+     * @param string                                                                                  $name         Name of the command
+     * @param array                                                                                   $args         Arguments to pass to the command
+     * @param HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>>|null $handlerStack Stack of middleware for the command
      */
     public function __construct(
         string $name,
@@ -32,6 +34,9 @@ class Command implements CommandInterface
         $this->handlerStack = $handlerStack;
     }
 
+    /**
+     * @return HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>>|null
+     */
     public function getHandlerStack(): ?HandlerStack
     {
         return $this->handlerStack;

--- a/src/CommandInterface.php
+++ b/src/CommandInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Command;
 
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\PromiseInterface;
 
 /**
  * A command object encapsulates the input parameters used to control the
@@ -19,6 +20,8 @@ interface CommandInterface extends \ArrayAccess, \IteratorAggregate, \Countable,
      * Retrieves the handler stack specific to this command's execution.
      *
      * This can be used to add middleware that is specific to the command instance.
+     *
+     * @return HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>>|null
      */
     public function getHandlerStack(): ?HandlerStack;
 

--- a/src/ServiceClient.php
+++ b/src/ServiceClient.php
@@ -20,30 +20,22 @@ class ServiceClient implements ServiceClientInterface
 {
     private HttpClient $httpClient;
 
+    /** @var HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>> */
     private HandlerStack $handlerStack;
 
-    /** @var callable */
+    /** @var callable(CommandInterface): RequestInterface */
     private $commandToRequestTransformer;
 
-    /** @var callable */
+    /** @var callable(ResponseInterface, RequestInterface, CommandInterface): ResultInterface */
     private $responseToResultTransformer;
 
     /**
      * Instantiates a Guzzle ServiceClient for making requests to a web service.
      *
-     * @param HttpClient        $httpClient                  A fully-configured Guzzle HTTP client that
-     *                                                       will be used to perform the underlying HTTP requests.
-     * @param callable          $commandToRequestTransformer A callable that transforms
-     *                                                       a Command into a Request. The function should accept a
-     *                                                       `GuzzleHttp\Command\CommandInterface` object and return a
-     *                                                       `Psr\Http\Message\RequestInterface` object.
-     * @param callable          $responseToResultTransformer A callable that transforms a
-     *                                                       Response into a Result. The function should accept a
-     *                                                       `Psr\Http\Message\ResponseInterface` object (and optionally a
-     *                                                       `Psr\Http\Message\RequestInterface` object) and return a
-     *                                                       `GuzzleHttp\Command\ResultInterface` object.
-     * @param HandlerStack|null $commandHandlerStack         A Guzzle HandlerStack, which can
-     *                                                       be used to add command-level middleware to the service client.
+     * @param HttpClient                                                                              $httpClient                  A fully-configured Guzzle HTTP client that will be used to perform the underlying HTTP requests.
+     * @param callable(CommandInterface): RequestInterface                                            $commandToRequestTransformer A callable that transforms a Command into a Request.
+     * @param callable(ResponseInterface, RequestInterface, CommandInterface): ResultInterface        $responseToResultTransformer A callable that transforms a Response into a Result.
+     * @param HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>>|null $commandHandlerStack         A Guzzle HandlerStack, which can be used to add command-level middleware to the service client.
      */
     public function __construct(
         HttpClient $httpClient,
@@ -54,7 +46,9 @@ class ServiceClient implements ServiceClientInterface
         $this->httpClient = $httpClient;
         $this->commandToRequestTransformer = $commandToRequestTransformer;
         $this->responseToResultTransformer = $responseToResultTransformer;
-        $this->handlerStack = $commandHandlerStack ?: new HandlerStack();
+        /** @var HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>> $handlerStack */
+        $handlerStack = $commandHandlerStack ?: new HandlerStack();
+        $this->handlerStack = $handlerStack;
         $this->handlerStack->setHandler($this->createCommandHandler());
     }
 
@@ -63,6 +57,9 @@ class ServiceClient implements ServiceClientInterface
         return $this->httpClient;
     }
 
+    /**
+     * @return HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>>
+     */
     public function getHandlerStack(): HandlerStack
     {
         return $this->handlerStack;
@@ -91,20 +88,37 @@ class ServiceClient implements ServiceClientInterface
         return $handler($command);
     }
 
+    /**
+     * Executes multiple commands synchronously.
+     *
+     * Numeric-string command keys may become integer keys before callbacks receive them. Null keys are stored as an empty string in the returned result array.
+     *
+     * @param array{
+     *     concurrency?: int|(callable(int): int),
+     *     fulfilled?: callable(ResultInterface, int|string|null): mixed,
+     *     rejected?: callable(mixed, int|string|null): mixed
+     * } $options
+     *
+     * @return array<array-key, mixed>
+     */
     public function executeAll(iterable $commands, array $options = []): array
     {
+        $fulfilled = $options['fulfilled'] ?? null;
+        $rejected = $options['rejected'] ?? null;
+
         // Modify provided callbacks to track results.
         $results = [];
-        $options['fulfilled'] = function ($v, $k) use (&$results, $options): void {
-            if (isset($options['fulfilled'])) {
-                $options['fulfilled']($v, $k);
+        $options['fulfilled'] = function ($v, $k) use (&$results, $fulfilled): void {
+            if ($fulfilled !== null) {
+                /** @var ResultInterface $v */
+                $fulfilled($v, $k);
             }
             $resultKey = $k === null ? '' : $k;
             $results[$resultKey] = $v;
         };
-        $options['rejected'] = function ($v, $k) use (&$results, $options): void {
-            if (isset($options['rejected'])) {
-                $options['rejected']($v, $k);
+        $options['rejected'] = function ($v, $k) use (&$results, $rejected): void {
+            if ($rejected !== null) {
+                $rejected($v, $k);
             }
             $resultKey = $k === null ? '' : $k;
             $results[$resultKey] = $v;
@@ -121,6 +135,12 @@ class ServiceClient implements ServiceClientInterface
     }
 
     /**
+     * @param array{
+     *     concurrency?: int|(callable(int): int),
+     *     fulfilled?: callable(ResultInterface, int|string|null, PromiseInterface<mixed, mixed>): mixed,
+     *     rejected?: callable(mixed, int|string|null, PromiseInterface<mixed, mixed>): mixed
+     * } $options
+     *
      * @return PromiseInterface<mixed, mixed>
      */
     public function executeAllAsync(iterable $commands, array $options = []): PromiseInterface
@@ -170,6 +190,8 @@ class ServiceClient implements ServiceClientInterface
 
     /**
      * Defines the main handler for commands that uses the HTTP client.
+     *
+     * @return callable(CommandInterface): PromiseInterface<ResultInterface, mixed>
      */
     private function createCommandHandler(): callable
     {

--- a/src/ServiceClientInterface.php
+++ b/src/ServiceClientInterface.php
@@ -51,11 +51,16 @@ interface ServiceClientInterface
     /**
      * Executes multiple commands concurrently using a fixed pool size.
      *
+     * Numeric-string command keys may become integer keys before callbacks receive them. Null keys are stored as an empty string in the returned result array.
+     *
      * @param iterable $commands Iterable that contains CommandInterface objects to execute with the client.
-     * @param array    $options  Associative array of options to apply.
-     *                           - concurrency: (int) Max number of commands to execute concurrently.
-     *                           - fulfilled: (callable) Function to invoke when a command completes.
-     *                           - rejected: (callable) Function to invoke when a command fails.
+     * @param array{
+     *     concurrency?: int|(callable(int): int),
+     *     fulfilled?: callable(ResultInterface, int|string|null): mixed,
+     *     rejected?: callable(mixed, int|string|null): mixed
+     * } $options
+     *
+     * @return array<array-key, mixed>
      */
     public function executeAll(iterable $commands, array $options = []): array;
 
@@ -64,10 +69,11 @@ interface ServiceClientInterface
      * fixed pool size.
      *
      * @param iterable $commands Iterable that contains CommandInterface objects to execute with the client.
-     * @param array    $options  Associative array of options to apply.
-     *                           - concurrency: (int) Max number of commands to execute concurrently.
-     *                           - fulfilled: (callable) Function to invoke when a command completes.
-     *                           - rejected: (callable) Function to invoke when a command fails.
+     * @param array{
+     *     concurrency?: int|(callable(int): int),
+     *     fulfilled?: callable(ResultInterface, int|string|null, PromiseInterface<mixed, mixed>): mixed,
+     *     rejected?: callable(mixed, int|string|null, PromiseInterface<mixed, mixed>): mixed
+     * } $options
      *
      * @return PromiseInterface<mixed, mixed>
      */
@@ -80,6 +86,8 @@ interface ServiceClientInterface
 
     /**
      * Get the HandlerStack which can be used to add middleware to the client.
+     *
+     * @return HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>>
      */
     public function getHandlerStack(): HandlerStack;
 }

--- a/tests/ServiceClientTest.php
+++ b/tests/ServiceClientTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Command\ServiceClient;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
@@ -53,6 +54,53 @@ class ServiceClientTest extends TestCase
         $serviceClient = new ServiceClient($httpClient, $fn, $fn, $handlers);
         $this->assertSame($httpClient, $serviceClient->getHttpClient());
         $this->assertSame($handlers, $serviceClient->getHandlerStack());
+    }
+
+    public function testResponseTransformerMayDeclareFewerArguments(): void
+    {
+        $client = $this->getServiceClient([
+            new Response(200, [], '{"foo":"bar"}'),
+        ]);
+
+        $result = $client->execute($client->getCommand('foo'));
+
+        $this->assertSame('bar', $result['foo']);
+    }
+
+    public function testResponseTransformerReceivesCommand(): void
+    {
+        $receivedCommand = null;
+        $client = new ServiceClient(
+            new HttpClient([
+                'handler' => new MockHandler([
+                    new Response(200, [], '{}'),
+                ]),
+            ]),
+            function (CommandInterface $command): RequestInterface {
+                return new Request('POST', '/', [], $command->getName());
+            },
+            function (
+                ResponseInterface $response,
+                RequestInterface $request,
+                CommandInterface $command
+            ) use (&$receivedCommand): Result {
+                $receivedCommand = $command;
+
+                return new Result([
+                    'command' => $command->getName(),
+                    'request' => (string) $request->getBody(),
+                    'status' => $response->getStatusCode(),
+                ]);
+            }
+        );
+
+        $command = $client->getCommand('foo');
+        $result = $client->execute($command);
+
+        $this->assertSame($command, $receivedCommand);
+        $this->assertSame('foo', $result['command']);
+        $this->assertSame('foo', $result['request']);
+        $this->assertSame(200, $result['status']);
     }
 
     public function testExecuteCommandViaMagicMethod(): void
@@ -112,12 +160,16 @@ class ServiceClientTest extends TestCase
         // Setup fulfilled/rejected callbacks, just to confirm they are called.
         $fulfilledFnCalled = false;
         $rejectedFnCalled = false;
+        $fulfilledArgs = [];
+        $rejectedArgs = [];
         $options = [
-            'fulfilled' => function () use (&$fulfilledFnCalled): void {
+            'fulfilled' => function (...$args) use (&$fulfilledFnCalled, &$fulfilledArgs): void {
                 $fulfilledFnCalled = true;
+                $fulfilledArgs = $args;
             },
-            'rejected' => function () use (&$rejectedFnCalled): void {
+            'rejected' => function (...$args) use (&$rejectedFnCalled, &$rejectedArgs): void {
                 $rejectedFnCalled = true;
+                $rejectedArgs = $args;
             },
         ];
 
@@ -127,6 +179,12 @@ class ServiceClientTest extends TestCase
         // Make sure the callbacks were called
         $this->assertTrue($fulfilledFnCalled);
         $this->assertTrue($rejectedFnCalled);
+        $this->assertCount(2, $fulfilledArgs);
+        $this->assertInstanceOf(Result::class, $fulfilledArgs[0]);
+        $this->assertContains($fulfilledArgs[1], [0, 2]);
+        $this->assertCount(2, $rejectedArgs);
+        $this->assertInstanceOf(CommandException::class, $rejectedArgs[0]);
+        $this->assertSame(1, $rejectedArgs[1]);
 
         // Validate that the results are as expected.
         $this->assertCount(3, $results);
@@ -200,5 +258,45 @@ class ServiceClientTest extends TestCase
 
         $client = $this->getServiceClient([]);
         $client->executeAll($generateCommands());
+    }
+
+    public function testExecuteAllAsyncCallbacksReceiveAggregatePromise(): void
+    {
+        $client = $this->getServiceClient([
+            new Response(200, [], '{"letter":"A"}'),
+            new BadResponseException(
+                'Bad Response',
+                $this->createMock(RequestInterface::class),
+                new Response(200, [], '{"error":"Not a letter"}')
+            ),
+        ]);
+
+        $commands = [
+            'success' => new Command('capitalize', ['letter' => 'a']),
+            'failure' => new Command('capitalize', ['letter' => '2']),
+        ];
+
+        $fulfilledKey = null;
+        $fulfilledPromise = null;
+        $rejectedKey = null;
+        $rejectedPromise = null;
+        $promise = $client->executeAllAsync($commands, [
+            'fulfilled' => function (Result $result, $key, PromiseInterface $aggregate) use (&$fulfilledKey, &$fulfilledPromise): void {
+                $fulfilledKey = $key;
+                $fulfilledPromise = $aggregate;
+            },
+            'rejected' => function ($reason, $key, PromiseInterface $aggregate) use (&$rejectedKey, &$rejectedPromise): void {
+                $this->assertInstanceOf(CommandException::class, $reason);
+                $rejectedKey = $key;
+                $rejectedPromise = $aggregate;
+            },
+        ]);
+
+        $promise->wait();
+
+        $this->assertSame('success', $fulfilledKey);
+        $this->assertSame($promise, $fulfilledPromise);
+        $this->assertSame('failure', $rejectedKey);
+        $this->assertSame($promise, $rejectedPromise);
     }
 }


### PR DESCRIPTION
This improves PHPDoc for command handler stacks, transformer callables, and concurrent command callbacks. It also documents the static-analysis impact and adds focused tests for existing callback arity behavior.