### PR TITLE
Deprecate non-iterable command collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 1.5.0 - Upcoming
 
-* Deprecated non-iterable command collections passed to `executeAll()` and
-  `executeAllAsync()`, which will be rejected in 2.0
+* Deprecate non-iterable command collections
 
 ## 1.4.0 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.5.0 - Upcoming
+
+* Deprecated non-iterable command collections passed to `executeAll()` and
+  `executeAllAsync()`, which will be rejected in 2.0
+
 ## 1.4.0 - 2026-05-18
 
 * Add PHP 8.5 support

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "php": "^7.2.5 || ^8.0",
         "guzzlehttp/guzzle": "^7.10",
         "guzzlehttp/promises": "^2.3",
-        "guzzlehttp/psr7": "^2.8"
+        "guzzlehttp/psr7": "^2.8",
+        "symfony/deprecation-contracts": "^2.2 || ^3.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,6 +7,12 @@ parameters:
 			path: src/Command.php
 
 		-
+			message: '#^Call to function is_iterable\(\) with array\|Iterator will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/ServiceClient.php
+
+		-
 			message: '#^Callable callable\(Psr\\Http\\Message\\RequestInterface, array\)\: GuzzleHttp\\Promise\\PromiseInterface invoked with 1 parameter, 2 required\.$#'
 			identifier: arguments.count
 			count: 1

--- a/src/ServiceClient.php
+++ b/src/ServiceClient.php
@@ -122,8 +122,19 @@ class ServiceClient implements ServiceClientInterface
             $options['concurrency'] = 25;
         }
 
-        // Convert the iterator of commands to a generator of promises.
-        $commands = Promise\Create::iterFor($commands);
+        if (!\is_iterable($commands)) {
+            @\trigger_error(
+                'Since guzzlehttp/command 1.5: Passing a non-iterable command collection to '
+                .'GuzzleHttp\\Command\\ServiceClient::executeAll() or '
+                .'GuzzleHttp\\Command\\ServiceClient::executeAllAsync() is deprecated; '
+                .'guzzlehttp/command 2.0 will require an iterable.',
+                \E_USER_DEPRECATED
+            );
+
+            $commands = [$commands];
+        }
+
+        // Convert the iterable of commands to a generator of promises.
         $promises = function () use ($commands) {
             foreach ($commands as $key => $command) {
                 if (!$command instanceof CommandInterface) {

--- a/src/ServiceClient.php
+++ b/src/ServiceClient.php
@@ -134,7 +134,8 @@ class ServiceClient implements ServiceClientInterface
             $commands = [$commands];
         }
 
-        // Convert the iterable of commands to a generator of promises.
+        // Convert the iterator of commands to a generator of promises.
+        $commands = Promise\Create::iterFor($commands);
         $promises = function () use ($commands) {
             foreach ($commands as $key => $command) {
                 if (!$command instanceof CommandInterface) {

--- a/src/ServiceClient.php
+++ b/src/ServiceClient.php
@@ -123,12 +123,12 @@ class ServiceClient implements ServiceClientInterface
         }
 
         if (!\is_iterable($commands)) {
-            @\trigger_error(
-                'Since guzzlehttp/command 1.5: Passing a non-iterable command collection to '
-                .'GuzzleHttp\\Command\\ServiceClient::executeAll() or '
-                .'GuzzleHttp\\Command\\ServiceClient::executeAllAsync() is deprecated; '
-                .'guzzlehttp/command 2.0 will require an iterable.',
-                \E_USER_DEPRECATED
+            \trigger_deprecation(
+                'guzzlehttp/command',
+                '1.5',
+                'Passing a non-iterable command collection to %s::executeAll() or %s::executeAllAsync() is deprecated; guzzlehttp/command 2.0 will require an iterable.',
+                __CLASS__,
+                __CLASS__
             );
 
             $commands = [$commands];

--- a/src/ServiceClientInterface.php
+++ b/src/ServiceClientInterface.php
@@ -51,12 +51,12 @@ interface ServiceClientInterface
     /**
      * Executes multiple commands concurrently using a fixed pool size.
      *
-     * @param iterable $commands Iterable that contains CommandInterface
-     *                           objects to execute with the client.
-     * @param array    $options  Associative array of options to apply.
-     *                           - concurrency: (int) Max number of commands to execute concurrently.
-     *                           - fulfilled: (callable) Function to invoke when a command completes.
-     *                           - rejected: (callable) Function to invoke when a command fails.
+     * @param array|\Iterator $commands Array or iterator that contains
+     *                                  CommandInterface objects to execute with the client.
+     * @param array           $options  Associative array of options to apply.
+     *                                  - concurrency: (int) Max number of commands to execute concurrently.
+     *                                  - fulfilled: (callable) Function to invoke when a command completes.
+     *                                  - rejected: (callable) Function to invoke when a command fails.
      *
      * @return array
      */
@@ -66,12 +66,12 @@ interface ServiceClientInterface
      * Executes multiple commands concurrently and asynchronously using a
      * fixed pool size.
      *
-     * @param iterable $commands Iterable that contains CommandInterface
-     *                           objects to execute with the client.
-     * @param array    $options  Associative array of options to apply.
-     *                           - concurrency: (int) Max number of commands to execute concurrently.
-     *                           - fulfilled: (callable) Function to invoke when a command completes.
-     *                           - rejected: (callable) Function to invoke when a command fails.
+     * @param array|\Iterator $commands Array or iterator that contains
+     *                                  CommandInterface objects to execute with the client.
+     * @param array           $options  Associative array of options to apply.
+     *                                  - concurrency: (int) Max number of commands to execute concurrently.
+     *                                  - fulfilled: (callable) Function to invoke when a command completes.
+     *                                  - rejected: (callable) Function to invoke when a command fails.
      *
      * @return PromiseInterface
      */

--- a/src/ServiceClientInterface.php
+++ b/src/ServiceClientInterface.php
@@ -51,12 +51,12 @@ interface ServiceClientInterface
     /**
      * Executes multiple commands concurrently using a fixed pool size.
      *
-     * @param array|\Iterator $commands Array or iterator that contains
-     *                                  CommandInterface objects to execute with the client.
-     * @param array           $options  Associative array of options to apply.
-     *                                  - concurrency: (int) Max number of commands to execute concurrently.
-     *                                  - fulfilled: (callable) Function to invoke when a command completes.
-     *                                  - rejected: (callable) Function to invoke when a command fails.
+     * @param iterable $commands Iterable that contains CommandInterface
+     *                           objects to execute with the client.
+     * @param array    $options  Associative array of options to apply.
+     *                           - concurrency: (int) Max number of commands to execute concurrently.
+     *                           - fulfilled: (callable) Function to invoke when a command completes.
+     *                           - rejected: (callable) Function to invoke when a command fails.
      *
      * @return array
      */
@@ -66,12 +66,12 @@ interface ServiceClientInterface
      * Executes multiple commands concurrently and asynchronously using a
      * fixed pool size.
      *
-     * @param array|\Iterator $commands Array or iterator that contains
-     *                                  CommandInterface objects to execute with the client.
-     * @param array           $options  Associative array of options to apply.
-     *                                  - concurrency: (int) Max number of commands to execute concurrently.
-     *                                  - fulfilled: (callable) Function to invoke when a command completes.
-     *                                  - rejected: (callable) Function to invoke when a command fails.
+     * @param iterable $commands Iterable that contains CommandInterface
+     *                           objects to execute with the client.
+     * @param array    $options  Associative array of options to apply.
+     *                           - concurrency: (int) Max number of commands to execute concurrently.
+     *                           - fulfilled: (callable) Function to invoke when a command completes.
+     *                           - rejected: (callable) Function to invoke when a command fails.
      *
      * @return PromiseInterface
      */


### PR DESCRIPTION
This makes command own the transition away from non-iterable command collections before command 2.0 requires iterables. The legacy one-item wrapping behavior is still preserved in 1.5 after emitting a command deprecation, while the current PHPDoc remains compatible with the documented array and iterator input shape.