### PR TITLE
Remove command collection deprecation shim

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "guzzlehttp/guzzle": "^8.0@dev",
         "guzzlehttp/promises": "^3.0@dev",
         "guzzlehttp/psr7": "^3.0@dev",
-        "psr/http-client": "^1.0",
-        "symfony/deprecation-contracts": "^2.2 || ^3.0"
+        "psr/http-client": "^1.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,2 @@
 parameters:
-	ignoreErrors:
-		-
-			message: '#^Call to function is_iterable\(\) with iterable will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/ServiceClient.php
+	ignoreErrors: []

--- a/src/ServiceClient.php
+++ b/src/ServiceClient.php
@@ -150,18 +150,6 @@ class ServiceClient implements ServiceClientInterface
             $options['concurrency'] = 25;
         }
 
-        if (!\is_iterable($commands)) {
-            \trigger_deprecation(
-                'guzzlehttp/command',
-                '1.5',
-                'Passing a non-iterable command collection to %s::executeAll() or %s::executeAllAsync() is deprecated; guzzlehttp/command 2.0 will require an iterable.',
-                __CLASS__,
-                __CLASS__
-            );
-
-            $commands = [$commands];
-        }
-
         // Convert the iterator of commands to a generator of promises.
         $commands = Promise\Create::iterFor($commands);
         $promises = function () use ($commands): \Generator {


### PR DESCRIPTION
This removes the temporary command collection deprecation shim that was carried forward by the 1.5 merge. Command 2.0 already requires iterable command collections through its native signatures, so the compatibility branch, temporary dependency, and PHPStan baseline entry are no longer needed.