### PR TITLE
Handle Guzzle 8 response exceptions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to function is_iterable\(\) with array\|Iterator will always evaluate to true\.$#'
+			message: '#^Call to function is_iterable\(\) with iterable will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/ServiceClient.php

--- a/src/Exception/CommandException.php
+++ b/src/Exception/CommandException.php
@@ -6,7 +6,7 @@ namespace GuzzleHttp\Command\Exception;
 
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -36,8 +36,8 @@ class CommandException extends \RuntimeException implements GuzzleException
             $request = $prev->getRequest();
         }
 
-        // Guzzle RequestException also exposes the optional Response.
-        if ($prev instanceof RequestException) {
+        // Guzzle response-aware exceptions also expose the Response.
+        if ($prev instanceof ResponseException) {
             $response = $prev->getResponse();
         }
 

--- a/tests/Exception/CommandExceptionTest.php
+++ b/tests/Exception/CommandExceptionTest.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Command\Exception\CommandClientException;
 use GuzzleHttp\Command\Exception\CommandException;
 use GuzzleHttp\Command\Exception\CommandServerException;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -57,7 +57,7 @@ class CommandExceptionTest extends TestCase
         $request = $this->createMock(RequestInterface::class);
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(404);
-        $previous = new RequestException('error', $request, $response);
+        $previous = new ResponseException('error', $request, $response);
 
         $exception = CommandException::fromPrevious($command, $previous);
         $this->assertInstanceOf(CommandClientException::class, $exception);
@@ -69,7 +69,7 @@ class CommandExceptionTest extends TestCase
         $request = $this->createMock(RequestInterface::class);
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(500);
-        $previous = new RequestException('error', $request, $response);
+        $previous = new ResponseException('error', $request, $response);
 
         $exception = CommandException::fromPrevious($command, $previous);
         $this->assertInstanceOf(CommandServerException::class, $exception);


### PR DESCRIPTION
This updates command exception wrapping for the Guzzle 8 exception hierarchy. Response-aware failures now use ResponseException when copying the response, and the affected tests construct response-aware Guzzle exceptions with the Guzzle 8 constructor shape.