### PR TITLE
Reject native PHP serialization of ServiceClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Drop support for PHP 7.2 and 7.3
 * Require `guzzlehttp/guzzle` ^8.0, `guzzlehttp/promises` ^3.0, and `guzzlehttp/psr7` ^3.0
 * Add generic PHPDoc return types to asynchronous service client APIs
+* Reject native PHP serialization of `ServiceClient`
 * Require custom implementations and subclasses of public command APIs to match native method signatures
 * Require service client response transformers to return `ResultInterface` values
 * Require custom middleware, transformers, and `executeAll()` callbacks to accept exact argument types instead of relying on scalar coercion

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,6 +28,11 @@ If your application still supports PHP 7.2 or 7.3, or still uses the Guzzle 7
 dependency stack, continue using Guzzle Command 1.x until your minimum PHP and
 dependency versions are raised.
 
+#### Native PHP Serialization Of Service Clients
+
+`ServiceClient` no longer supports native PHP `serialize()` or `unserialize()`.
+Persist command names and parameter arrays instead of runtime client objects.
+
 #### Strict Types and Extension Points
 
 Guzzle Command source and test files now declare strict types. This mostly

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,11 +28,6 @@ If your application still supports PHP 7.2 or 7.3, or still uses the Guzzle 7
 dependency stack, continue using Guzzle Command 1.x until your minimum PHP and
 dependency versions are raised.
 
-#### Native PHP Serialization Of Service Clients
-
-`ServiceClient` no longer supports native PHP `serialize()` or `unserialize()`.
-Persist command names and parameter arrays instead of runtime client objects.
-
 #### Strict Types and Extension Points
 
 Guzzle Command source and test files now declare strict types. This mostly
@@ -92,6 +87,11 @@ or `callable` PHPDoc.
 the command key. `executeAllAsync()` callback annotations include the same first
 two arguments plus the aggregate promise as a third argument. Lower-arity
 userland callbacks continue to work at runtime when PHP accepts them.
+
+#### Native PHP Serialization of Service Clients
+
+`ServiceClient` no longer supports native PHP `serialize()` or `unserialize()`.
+Persist command names and parameter arrays instead of runtime client objects.
 
 1.0 from 0.8
 ------------

--- a/src/NonSerializableTrait.php
+++ b/src/NonSerializableTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Command;
+
+/**
+ * @internal
+ */
+trait NonSerializableTrait
+{
+    public function __serialize(): array
+    {
+        throw new \LogicException(static::class.' should never be serialized');
+    }
+
+    public function __unserialize(array $data): void
+    {
+        throw new \LogicException(static::class.' should never be unserialized');
+    }
+}

--- a/src/ServiceClient.php
+++ b/src/ServiceClient.php
@@ -18,6 +18,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class ServiceClient implements ServiceClientInterface
 {
+    use NonSerializableTrait;
+
     private HttpClient $httpClient;
 
     /** @var HandlerStack<callable(CommandInterface): PromiseInterface<ResultInterface, mixed>> */


### PR DESCRIPTION
This rejects native PHP serialization for ServiceClient and documents the new behavior. Command objects remain unchanged so data-only command payloads are unaffected.