### PR TITLE
Reject single commands in executeAll and executeAllAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Reject native PHP serialization of `ServiceClient`
 * Require custom implementations and subclasses of public command APIs to match native method signatures
 * Require service client response transformers to return `ResultInterface` values
+* Require command collections to be iterable and reject single commands in `executeAll()` and `executeAllAsync()`
 * Require custom middleware, transformers, and `executeAll()` callbacks to accept exact argument types instead of relying on scalar coercion
 * Preserve requests from PSR-18 request and network exceptions when wrapping command failures
 * Improve PHPDoc for command handler stacks, transformer callables, and concurrent command callbacks

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -65,6 +65,22 @@ callbacks.
 3.x. Code using Guzzle Promises directly should account for its 3.0 behavior and
 signature changes.
 
+#### Concurrent Command Collections
+
+`executeAll()` and `executeAllAsync()` now require an iterable of commands.
+Passing a non-iterable throws a `TypeError`, and passing a single command
+throws an `InvalidArgumentException`. In 1.x a single command was executed as
+a one-element collection.
+
+```php
+// 1.x executed the single command; 2.0 throws:
+$results = $client->executeAll($command);
+
+// Wrap single commands, or execute them directly:
+$results = $client->executeAll([$command]);
+$result = $client->execute($command);
+```
+
 #### Generic Promise And Structured PHPDoc Types
 
 Guzzle Command's async service client APIs and command handler stack annotations

--- a/src/ServiceClient.php
+++ b/src/ServiceClient.php
@@ -147,6 +147,12 @@ class ServiceClient implements ServiceClientInterface
      */
     public function executeAllAsync(iterable $commands, array $options = []): PromiseInterface
     {
+        // A single command satisfies the iterable type but would be iterated
+        // as a collection of its own parameters.
+        if ($commands instanceof CommandInterface) {
+            throw new \InvalidArgumentException(\sprintf('%s::executeAllAsync() requires an iterable of commands; a single command was given. Wrap it in an array or use executeAsync() instead.', __CLASS__));
+        }
+
         // Apply default concurrency.
         if (!isset($options['concurrency'])) {
             $options['concurrency'] = 25;

--- a/tests/ServiceClientTest.php
+++ b/tests/ServiceClientTest.php
@@ -280,6 +280,24 @@ class ServiceClientTest extends TestCase
         $client->executeAll($generateCommands());
     }
 
+    public function testExecuteAllRejectsSingleCommand(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires an iterable of commands');
+
+        $client = $this->getServiceClient([]);
+        $client->executeAll(new Command('capitalize', ['letter' => 'a']));
+    }
+
+    public function testExecuteAllAsyncRejectsSingleCommand(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires an iterable of commands');
+
+        $client = $this->getServiceClient([]);
+        $client->executeAllAsync(new Command('capitalize', ['letter' => 'a']));
+    }
+
     public function testExecuteAllAsyncCallbacksReceiveAggregatePromise(): void
     {
         $client = $this->getServiceClient([


### PR DESCRIPTION
`CommandInterface` extends `IteratorAggregate`, so a single command satisfies the new `iterable` parameter type on `executeAll()` and `executeAllAsync()` and is iterated as a collection of its own parameters: a command without parameters silently produces an empty result array with no request sent, and a command with parameters fails with a confusing message about the iterator yielding non-commands. On 1.5 this worked only because Promises 2.x wrapped `IteratorAggregate` inputs as a single element, and the 1.5 deprecation shim never fired for commands since they are already iterable.

This rejects single commands up front with a clear message, adds regression tests for both methods, and documents the iterable requirement promised by the 1.5 deprecation in the changelog and upgrade guide.
