### PR TITLE
Fix Guzzle middleware doc link for the 8.0 docs split

### DIFF
--- a/docs/middleware-extending-the-client.md
+++ b/docs/middleware-extending-the-client.md
@@ -13,7 +13,7 @@ client stack:
 
 - Command middleware receives commands and resolves to results.
 - HTTP middleware receives PSR-7 requests and resolves to PSR-7 responses.
-- Use [Guzzle HTTP middleware](https://github.com/guzzle/guzzle/blob/8.0/docs/handlers-and-middleware.md#middleware) for transport behavior such as retries, signing, logging, and request/response inspection.
+- Use [Guzzle HTTP middleware](https://github.com/guzzle/guzzle/blob/8.0/docs/middleware.md) for transport behavior such as retries, signing, logging, and request/response inspection.
 
 ## Adding Command Middleware
 


### PR DESCRIPTION
Guzzle 8.0 split the combined handlers-and-middleware documentation page into separate `handlers.md` and `middleware.md` pages, so the link in the middleware guide pointing at `docs/handlers-and-middleware.md#middleware` targets a page that no longer exists on the 8.0 branch. This updates it to point at the dedicated middleware page, which is what the surrounding sentence describes. This was the only remaining stale Guzzle docs link in the repository.
