### PR TITLE
Preserve and document command exception context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 * Require service client response transformers to return `ResultInterface` values
 * Require command collections to be iterable and reject single commands in `executeAll()` and `executeAllAsync()`
 * Require custom middleware, transformers, and `executeAll()` callbacks to accept exact argument types instead of relying on scalar coercion
-* Preserve requests from PSR-18 request and network exceptions when wrapping command failures
+* Preserve requests from PSR-18 request and network exceptions and from Guzzle transfer exceptions when wrapping command failures
+* Allow command exception constructors to accept any previous `Throwable`
 * Improve PHPDoc for command handler stacks, transformer callables, and concurrent command callbacks
 
 ## 1.5.1 - 2026-06-23

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -49,6 +49,14 @@ or `ToArrayInterface` must update method signatures to remain compatible.
 
 Classes extending package classes should also update overridden method signatures.
 
+#### Command Exceptions
+
+Direct construction of `CommandException`, `CommandClientException`, and
+`CommandServerException` now accepts `?\Throwable` for the previous exception
+argument. Guzzle Command still wraps command execution failures through
+`CommandException::fromPrevious()` when service-client execution catches an
+`Exception`.
+
 #### Per-command HTTP Options
 
 `GuzzleHttp\Command\ServiceClient` still reserves the `@http` command parameter

--- a/src/Exception/CommandException.php
+++ b/src/Exception/CommandException.php
@@ -7,6 +7,7 @@ namespace GuzzleHttp\Command\Exception;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Exception\TransferException;
 use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
@@ -32,7 +33,9 @@ class CommandException extends \RuntimeException implements GuzzleException
 
         // If the exception is request-aware, preserve the Request.
         $request = $response = null;
-        if ($prev instanceof RequestExceptionInterface || $prev instanceof NetworkExceptionInterface) {
+        if ($prev instanceof TransferException) {
+            $request = $prev->getRequest();
+        } elseif ($prev instanceof RequestExceptionInterface || $prev instanceof NetworkExceptionInterface) {
             $request = $prev->getRequest();
         }
 

--- a/tests/Exception/CommandExceptionTest.php
+++ b/tests/Exception/CommandExceptionTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Command\Exception\CommandClientException;
 use GuzzleHttp\Command\Exception\CommandException;
 use GuzzleHttp\Command\Exception\CommandServerException;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\HandlerClosedException;
 use GuzzleHttp\Exception\ResponseException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\RequestExceptionInterface;
@@ -61,6 +62,9 @@ class CommandExceptionTest extends TestCase
 
         $exception = CommandException::fromPrevious($command, $previous);
         $this->assertInstanceOf(CommandClientException::class, $exception);
+        $this->assertSame($request, $exception->getRequest());
+        $this->assertSame($response, $exception->getResponse());
+        $this->assertSame($previous, $exception->getPrevious());
     }
 
     public function testFactoryReturnsServerExceptionFor500LevelStatusCode(): void
@@ -73,6 +77,9 @@ class CommandExceptionTest extends TestCase
 
         $exception = CommandException::fromPrevious($command, $previous);
         $this->assertInstanceOf(CommandServerException::class, $exception);
+        $this->assertSame($request, $exception->getRequest());
+        $this->assertSame($response, $exception->getResponse());
+        $this->assertSame($previous, $exception->getPrevious());
     }
 
     public function testFactoryCopiesRequestFromNetworkException(): void
@@ -80,6 +87,18 @@ class CommandExceptionTest extends TestCase
         $command = $this->createMock(CommandInterface::class);
         $request = $this->createMock(RequestInterface::class);
         $previous = new ConnectException('error', $request);
+
+        $exception = CommandException::fromPrevious($command, $previous);
+        $this->assertSame($request, $exception->getRequest());
+        $this->assertNull($exception->getResponse());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testFactoryCopiesRequestFromGuzzleTransferException(): void
+    {
+        $command = $this->createMock(CommandInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $previous = new HandlerClosedException('error', $request);
 
         $exception = CommandException::fromPrevious($command, $previous);
         $this->assertSame($request, $exception->getRequest());


### PR DESCRIPTION
`CommandException::fromPrevious()` only preserved requests from PSR-18 request and network exceptions, so request-bearing Guzzle 8 transfer exceptions such as `HandlerClosedException` were wrapped with `getRequest()` returning null. Command wrapping now copies the request from any Guzzle `TransferException`, while non-Guzzle PSR-18 exceptions remain supported. The 4xx and 5xx factory tests now also pin request, response, and previous-exception preservation, and the release notes document both the widened request preservation and that the command exception constructors accept any previous `Throwable`.