### PR TITLE
Cover ServiceClient serialization rejection

### DIFF
--- a/tests/ServiceClientTest.php
+++ b/tests/ServiceClientTest.php
@@ -298,6 +298,29 @@ class ServiceClientTest extends TestCase
         $client->executeAllAsync(new Command('capitalize', ['letter' => 'a']));
     }
 
+    public function testRejectsNativeSerialization(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(ServiceClient::class.' should never be serialized');
+
+        $client = $this->getServiceClient([]);
+        serialize($client);
+    }
+
+    public function testRejectsNativeUnserialization(): void
+    {
+        $payload = sprintf(
+            'O:%d:"%s":0:{}',
+            strlen(ServiceClient::class),
+            ServiceClient::class
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(ServiceClient::class.' should never be unserialized');
+
+        unserialize($payload);
+    }
+
     public function testExecuteAllAsyncCallbacksReceiveAggregatePromise(): void
     {
         $client = $this->getServiceClient([


### PR DESCRIPTION
`ServiceClient` uses `NonSerializableTrait` and the 2.0 release notes document that native PHP serialization is rejected, but nothing pinned that behavior: the suite would still pass if the trait were silently dropped. This adds two focused tests asserting that `serialize()` and a crafted native object payload both throw the trait's `LogicException`s with their class-specific messages, proving the failures come from `NonSerializableTrait` on `ServiceClient` rather than from an incidental serialization failure of nested handler or client state.