### PR TITLE
Tidy command 2.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * Drop support for PHP 7.2 and 7.3
 * Require `guzzlehttp/guzzle` ^8.0, `guzzlehttp/promises` ^3.0, and `guzzlehttp/psr7` ^3.0
-* Add generic PHPDoc return types to asynchronous service client APIs
 * Reject native PHP serialization of `ServiceClient`
 * Require custom implementations and subclasses of public command APIs to match native method signatures
 * Require service client response transformers to return `ResultInterface` values
@@ -12,6 +11,7 @@
 * Require custom middleware, transformers, and `executeAll()` callbacks to accept exact argument types instead of relying on scalar coercion
 * Preserve requests from PSR-18 request and network exceptions and from Guzzle transfer exceptions when wrapping command failures
 * Allow command exception constructors to accept any previous `Throwable`
+* Add generic PHPDoc return types to asynchronous service client APIs
 * Improve PHPDoc for command handler stacks, transformer callables, and concurrent command callbacks
 
 ## 1.5.1 - 2026-06-23

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,8 +19,8 @@ Guzzle Command 2.0 also requires
 [Guzzle 8.x](https://github.com/guzzle/guzzle/blob/8.0/UPGRADING.md),
 [Guzzle Promises 3.x](https://github.com/guzzle/promises/blob/3.0/UPGRADING.md),
 and [Guzzle PSR-7 3.x](https://github.com/guzzle/psr7/blob/3.0/UPGRADING.md).
-Guzzle Command 1.x supported Guzzle `^7.11`, Guzzle Promises `^2.5`, and Guzzle
-PSR-7 `^2.11`.
+The latest Guzzle Command 1.x release requires Guzzle `^7.12.3`, Guzzle
+Promises `^2.5`, and Guzzle PSR-7 `^2.12.3`.
 
 Guzzle Command 2.0 now requires `psr/http-client:^1.0` directly.
 


### PR DESCRIPTION
The upgrade guide compared 2.0 against stale 1.x dependency floors: the latest 1.x release requires Guzzle `^7.12.3` and Guzzle PSR-7 `^2.12.3`, not the `^7.11` and `^2.11` floors the guide still quoted. The dependency baseline sentence now describes the latest 1.x release. The 2.0.0 changelog also gave the generic async PHPDoc bullet more prominence than runtime behavior changes; it now sits with the other static-analysis-only PHPDoc note at the end of the section so runtime changes come first. No bullet wording changed.