### PR TITLE
Wrap documentation prose to 80 columns

### DIFF
--- a/docs/async-and-concurrency.md
+++ b/docs/async-and-concurrency.md
@@ -1,6 +1,9 @@
 # Async and Concurrency
 
-This page explains asynchronous command execution and concurrent command pools for Guzzle Command service clients. For promise chaining, waiting, cancellation, and rejection behavior, see the [Guzzle Promises quick start](https://github.com/guzzle/promises/blob/3.0/docs/promise-quick-start.md).
+This page explains asynchronous command execution and concurrent command pools
+for Guzzle Command service clients. For promise chaining, waiting, cancellation,
+and rejection behavior, see the
+[Guzzle Promises quick start](https://github.com/guzzle/promises/blob/3.0/docs/promise-quick-start.md).
 
 ## Asynchronous Commands
 
@@ -30,8 +33,8 @@ echo $result['fizz']; //> 'buzz'
 ```
 
 Magic methods may also be used asynchronously by appending `Async` to the
-operation name. For example, `fooAsync()` creates a `foo` command and executes it
-asynchronously:
+operation name. For example, `fooAsync()` creates a `foo` command and executes
+it asynchronously:
 
 ```php
 $promise = $client->fooAsync(['baz' => 'bar']);
@@ -42,7 +45,8 @@ If built-in execution fails, the promise is typically rejected with a
 `GuzzleHttp\Command\Exception\CommandException`. When HTTP errors are enabled,
 4xx and 5xx responses are represented by `CommandClientException` and
 `CommandServerException`, respectively, when the underlying Guzzle exception
-contains a response. Custom middleware and handlers may reject with other values.
+contains a response. Custom middleware and handlers may reject with other
+values.
 
 ## Concurrent Commands
 
@@ -79,9 +83,9 @@ $results = $client->executeAll($commands, [
 ]);
 ```
 
-`executeAllAsync()` returns a promise for the command pool instead of waiting for
-it immediately. It resolves with `null` after all commands have settled; it does
-not build a result array. Individual command results are delivered to the
+`executeAllAsync()` returns a promise for the command pool instead of waiting
+for it immediately. It resolves with `null` after all commands have settled; it
+does not build a result array. Individual command results are delivered to the
 `fulfilled` callback, and individual rejection reasons are delivered to the
 `rejected` callback. Fulfilled and rejected callbacks may also declare the
 aggregate promise as a third argument:
@@ -113,8 +117,8 @@ The supported options are:
   when an individual command succeeds. `executeAllAsync()` also passes the
   aggregate promise as a third argument.
 - `rejected`: Callable invoked as `rejected($reason, $key)` by `executeAll()`
-  when an individual command fails. `executeAllAsync()` also passes the aggregate
-  promise as a third argument.
+  when an individual command fails. `executeAllAsync()` also passes the
+  aggregate promise as a third argument.
 
 Choose a concurrency value that is appropriate for the remote service and your
 application. Very large command lists should generally be streamed with an

--- a/docs/executing-commands.md
+++ b/docs/executing-commands.md
@@ -108,8 +108,8 @@ $command = $client->getCommand('foo', [
 ]);
 ```
 
-When setting per-command HTTP options intentionally, only expose and validate the
-specific options your application needs:
+When setting per-command HTTP options intentionally, only expose and validate
+the specific options your application needs:
 
 ```php
 use GuzzleHttp\RequestOptions;

--- a/docs/middleware-extending-the-client.md
+++ b/docs/middleware-extending-the-client.md
@@ -5,15 +5,19 @@ implement additional behavior and customize the `Command`-to-`Result` and
 `Request`-to-`Response` lifecycles, respectively.
 
 Command middleware is added to the service client's handler stack and wraps
-commands before they are transformed into HTTP requests. Command handlers use the
-shape `callable(GuzzleHttp\Command\CommandInterface): GuzzleHttp\Promise\PromiseInterface<GuzzleHttp\Command\ResultInterface, mixed>`. HTTP middleware should be configured on the underlying Guzzle HTTP client instead.
+commands before they are transformed into HTTP requests. Command handlers use
+the shape `callable(GuzzleHttp\Command\CommandInterface): GuzzleHttp\Promise\PromiseInterface<GuzzleHttp\Command\ResultInterface, mixed>`.
+HTTP middleware should be configured on the underlying Guzzle HTTP client
+instead.
 
 The service client's command stack is separate from the underlying Guzzle HTTP
 client stack:
 
 - Command middleware receives commands and resolves to results.
 - HTTP middleware receives PSR-7 requests and resolves to PSR-7 responses.
-- Use [Guzzle HTTP middleware](https://github.com/guzzle/guzzle/blob/8.0/docs/middleware.md) for transport behavior such as retries, signing, logging, and request/response inspection.
+- Use [Guzzle HTTP middleware](https://github.com/guzzle/guzzle/blob/8.0/docs/middleware.md)
+  for transport behavior such as retries, signing, logging, and request/response
+  inspection.
 
 ## Adding Command Middleware
 

--- a/docs/service-clients.md
+++ b/docs/service-clients.md
@@ -153,8 +153,8 @@ It receives PSR-7 requests after a command has been transformed and before the
 request is sent.
 
 Use command middleware for operation-level concerns, such as adding command
-defaults or inspecting results. Use HTTP middleware for transport-level concerns,
-such as request signing, retries, or logging raw HTTP messages.
+defaults or inspecting results. Use HTTP middleware for transport-level
+concerns, such as request signing, retries, or logging raw HTTP messages.
 
 ## Related
 


### PR DESCRIPTION
Reflows the documentation prose to a greedy 80-column width so the Markdown reads consistently and diffs stay small. Only line breaks move; no wording changes, and fenced code blocks, tables, and headings are left untouched. There are no code changes.